### PR TITLE
OO 3.* and uv

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,9 +9,6 @@ import sys
 script_directory = os.path.dirname(os.path.realpath(__file__))
 os.chdir(script_directory)
 
-subprocess.run("python -m venv .venv", check=True)
-subprocess.run(r'.venv\Scripts\pip install .', check=True)
-
-command_args = [r".venv\Scripts\python", "-m", "robot_framework"] + sys.argv[1:]
-
+subprocess.run("pip install --upgrade uv", check=True)
+command_args = ["uv", "run", "python", "-m", "robot_framework"] + sys.argv[1:]
 subprocess.run(command_args, check=True)


### PR DESCRIPTION
Bump OpenOrchestrator dependency to 3.* and switch main.py to the uv-based bootstrap.